### PR TITLE
Unity scene config save/load editor

### DIFF
--- a/Assets/Editor/SaveSettingsUtility.cs
+++ b/Assets/Editor/SaveSettingsUtility.cs
@@ -1,0 +1,53 @@
+#if UNITY_EDITOR
+using System.IO;
+using Scaffold;
+using UnityEditor;
+using UnityEngine;
+
+public static class SaveSettingsUtility
+{
+    private const string DefaultAssetPath = "Assets/Settings/SaveSettings.asset";
+
+    public static SaveSettings LoadOrCreateSettingsAsset(string assetPath = DefaultAssetPath)
+    {
+        var settings = AssetDatabase.LoadAssetAtPath<SaveSettings>(assetPath);
+        if (settings != null) return settings;
+
+        string folder = Path.GetDirectoryName(assetPath);
+        if (!AssetDatabase.IsValidFolder(folder))
+        {
+            CreateFoldersRecursively(folder);
+        }
+
+        settings = ScriptableObject.CreateInstance<SaveSettings>();
+        AssetDatabase.CreateAsset(settings, assetPath);
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+        return settings;
+    }
+
+    [MenuItem("Tools/Save Settings/Open Asset")]
+    public static void OpenSettingsAsset()
+    {
+        var settings = LoadOrCreateSettingsAsset();
+        Selection.activeObject = settings;
+        EditorGUIUtility.PingObject(settings);
+    }
+
+    private static void CreateFoldersRecursively(string folderPath)
+    {
+        if (string.IsNullOrEmpty(folderPath)) return;
+        var parts = folderPath.Replace('\\', '/').Split('/');
+        string current = parts[0];
+        for (int i = 1; i < parts.Length; i++)
+        {
+            string next = current + "/" + parts[i];
+            if (!AssetDatabase.IsValidFolder(next))
+            {
+                AssetDatabase.CreateFolder(current, parts[i]);
+            }
+            current = next;
+        }
+    }
+}
+#endif

--- a/Assets/Editor/SceneConfigWindow.cs
+++ b/Assets/Editor/SceneConfigWindow.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 public class SceneConfigWindow : EditorWindow
 {
     private string lastDirectory;
+    private SaveSettings settings;
 
     [MenuItem("Tools/Scene Config")] 
     public static void ShowWindow()
@@ -15,10 +16,40 @@ public class SceneConfigWindow : EditorWindow
         GetWindow<SceneConfigWindow>("Scene Config");
     }
 
+    private void OnEnable()
+    {
+#if UNITY_EDITOR
+        // Try load or create default settings asset
+        if (settings == null)
+        {
+            settings = SaveSettingsUtility.LoadOrCreateSettingsAsset();
+        }
+#endif
+    }
+
     private void OnGUI()
     {
         EditorGUILayout.Space();
         EditorGUILayout.LabelField("JSON конфиг сцены", EditorStyles.boldLabel);
+        EditorGUILayout.Space();
+
+        settings = (SaveSettings)EditorGUILayout.ObjectField("Save Settings", settings, typeof(SaveSettings), false);
+        if (settings == null)
+        {
+            if (GUILayout.Button("Создать SaveSettings", GUILayout.Height(22)))
+            {
+#if UNITY_EDITOR
+                settings = SaveSettingsUtility.LoadOrCreateSettingsAsset();
+#endif
+            }
+        }
+        else
+        {
+            EditorGUILayout.LabelField("Папка по умолчанию:", settings.ResolveFolderAbsolute());
+            EditorGUILayout.LabelField("Файл по умолчанию:", settings.ResolveDefaultFileAbsolute());
+            EditorGUILayout.LabelField("Компонентов для сохранения:", settings.componentScripts?.Count.ToString() ?? "0");
+        }
+
         EditorGUILayout.Space();
 
         if (GUILayout.Button("Сохранить в JSON", GUILayout.Height(28)))
@@ -35,6 +66,17 @@ public class SceneConfigWindow : EditorWindow
         EditorGUILayout.LabelField("Последняя папка:", string.IsNullOrEmpty(lastDirectory) ? "(не выбрана)" : lastDirectory);
     }
 
+    private string GetDefaultDirectory()
+    {
+        if (!string.IsNullOrEmpty(lastDirectory)) return lastDirectory;
+        if (settings != null)
+        {
+            var folder = settings.ResolveFolderAbsolute();
+            if (!string.IsNullOrEmpty(folder)) return folder;
+        }
+        return Application.dataPath;
+    }
+
     private void SaveToJson()
     {
         var config = SaveServiceLocator.Current.LoadSceneConfig();
@@ -44,8 +86,9 @@ public class SceneConfigWindow : EditorWindow
             return;
         }
 
-        string defaultDir = string.IsNullOrEmpty(lastDirectory) ? Application.dataPath : lastDirectory;
-        string path = EditorUtility.SaveFilePanel("Сохранить SceneConfig в JSON", defaultDir, "SceneConfig", "json");
+        string defaultDir = GetDefaultDirectory();
+        string defaultName = settings != null ? Path.GetFileName(settings.ResolveDefaultFileAbsolute()) : "SceneConfig.json";
+        string path = EditorUtility.SaveFilePanel("Сохранить SceneConfig в JSON", defaultDir, Path.GetFileNameWithoutExtension(defaultName), "json");
         if (string.IsNullOrEmpty(path))
         {
             return;
@@ -60,7 +103,7 @@ public class SceneConfigWindow : EditorWindow
 
     private void LoadFromJson()
     {
-        string defaultDir = string.IsNullOrEmpty(lastDirectory) ? Application.dataPath : lastDirectory;
+        string defaultDir = GetDefaultDirectory();
         string path = EditorUtility.OpenFilePanel("Загрузить SceneConfig из JSON", defaultDir, "json");
         if (string.IsNullOrEmpty(path))
         {
@@ -68,7 +111,7 @@ public class SceneConfigWindow : EditorWindow
         }
 
         string json = File.ReadAllText(path);
-        var config = JsonUtility.FromJson<SceneConfig>(json);
+        var config = JsonUtility.FromJson<Scaffold.SceneConfig>(json);
         if (config == null)
         {
             EditorUtility.DisplayDialog("Ошибка", "Не удалось распарсить JSON в SceneConfig.", "OK");

--- a/Assets/Editor/SceneConfigWindow.cs
+++ b/Assets/Editor/SceneConfigWindow.cs
@@ -1,0 +1,84 @@
+#if UNITY_EDITOR
+using System.IO;
+using Scaffold;
+using Services;
+using UnityEditor;
+using UnityEngine;
+
+public class SceneConfigWindow : EditorWindow
+{
+    private string lastDirectory;
+
+    [MenuItem("Tools/Scene Config")] 
+    public static void ShowWindow()
+    {
+        GetWindow<SceneConfigWindow>("Scene Config");
+    }
+
+    private void OnGUI()
+    {
+        EditorGUILayout.Space();
+        EditorGUILayout.LabelField("JSON конфиг сцены", EditorStyles.boldLabel);
+        EditorGUILayout.Space();
+
+        if (GUILayout.Button("Сохранить в JSON", GUILayout.Height(28)))
+        {
+            SaveToJson();
+        }
+
+        if (GUILayout.Button("Загрузить из JSON", GUILayout.Height(28)))
+        {
+            LoadFromJson();
+        }
+
+        EditorGUILayout.Space();
+        EditorGUILayout.LabelField("Последняя папка:", string.IsNullOrEmpty(lastDirectory) ? "(не выбрана)" : lastDirectory);
+    }
+
+    private void SaveToJson()
+    {
+        var config = SaveServiceLocator.Current.LoadSceneConfig();
+        if (config == null)
+        {
+            EditorUtility.DisplayDialog("Нет данных", "SaveService вернул null.", "OK");
+            return;
+        }
+
+        string defaultDir = string.IsNullOrEmpty(lastDirectory) ? Application.dataPath : lastDirectory;
+        string path = EditorUtility.SaveFilePanel("Сохранить SceneConfig в JSON", defaultDir, "SceneConfig", "json");
+        if (string.IsNullOrEmpty(path))
+        {
+            return;
+        }
+
+        string json = JsonUtility.ToJson(config, true);
+        File.WriteAllText(path, json);
+
+        lastDirectory = Path.GetDirectoryName(path);
+        Debug.Log($"SceneConfig сохранён: {path}");
+    }
+
+    private void LoadFromJson()
+    {
+        string defaultDir = string.IsNullOrEmpty(lastDirectory) ? Application.dataPath : lastDirectory;
+        string path = EditorUtility.OpenFilePanel("Загрузить SceneConfig из JSON", defaultDir, "json");
+        if (string.IsNullOrEmpty(path))
+        {
+            return;
+        }
+
+        string json = File.ReadAllText(path);
+        var config = JsonUtility.FromJson<SceneConfig>(json);
+        if (config == null)
+        {
+            EditorUtility.DisplayDialog("Ошибка", "Не удалось распарсить JSON в SceneConfig.", "OK");
+            return;
+        }
+
+        SaveServiceLocator.Current.SaveSceneConfig(config);
+
+        lastDirectory = Path.GetDirectoryName(path);
+        Debug.Log($"SceneConfig загружен из JSON и применён к SaveService: {path}");
+    }
+}
+#endif

--- a/Assets/Scripts/Scaffold/ISaveService.cs
+++ b/Assets/Scripts/Scaffold/ISaveService.cs
@@ -1,0 +1,33 @@
+using Scaffold;
+
+namespace Services
+{
+    public interface ISaveService
+    {
+        SceneConfig LoadSceneConfig();
+        void SaveSceneConfig(SceneConfig config);
+    }
+
+    public static class SaveServiceLocator
+    {
+        private static ISaveService current;
+
+        public static ISaveService Current
+        {
+            get
+            {
+                if (current == null)
+                {
+                    current = new InMemorySaveService();
+                }
+
+                return current;
+            }
+        }
+
+        public static void Set(ISaveService instance)
+        {
+            current = instance;
+        }
+    }
+}

--- a/Assets/Scripts/Scaffold/InMemorySaveService.cs
+++ b/Assets/Scripts/Scaffold/InMemorySaveService.cs
@@ -1,0 +1,19 @@
+using Scaffold;
+
+namespace Services
+{
+    public class InMemorySaveService : ISaveService
+    {
+        private SceneConfig cachedConfig = new SceneConfig();
+
+        public SceneConfig LoadSceneConfig()
+        {
+            return cachedConfig;
+        }
+
+        public void SaveSceneConfig(SceneConfig config)
+        {
+            cachedConfig = config ?? new SceneConfig();
+        }
+    }
+}

--- a/Assets/Scripts/Scaffold/SaveSettings.cs
+++ b/Assets/Scripts/Scaffold/SaveSettings.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Scaffold
+{
+    public enum SavePathMode
+    {
+        ProjectRelative,
+        Absolute,
+        PersistentDataPath
+    }
+
+    [CreateAssetMenu(fileName = "SaveSettings", menuName = "Scaffold/Save Settings", order = 0)]
+    public class SaveSettings : ScriptableObject
+    {
+        [Header("Location")]
+        public SavePathMode pathMode = SavePathMode.ProjectRelative;
+
+        [Tooltip("Folder relative to project root (when PathMode = ProjectRelative), e.g. Assets/Scaffold/Configs")] 
+        public string projectRelativeFolder = "Assets/Scaffold/Configs";
+
+        [Tooltip("Absolute folder on disk (when PathMode = Absolute)")]
+        public string absoluteFolder = "/tmp";
+
+        [Tooltip("Default file name for scene config JSON")]
+        public string defaultFileName = "SceneConfig.json";
+
+        [Header("Components to Save")]
+        [Tooltip("MonoScripts whose types derive from UnityEngine.Component and are considered in save process")] 
+        public List<MonoScript> componentScripts = new List<MonoScript>();
+
+        public string ResolveFolderAbsolute()
+        {
+            switch (pathMode)
+            {
+                case SavePathMode.ProjectRelative:
+#if UNITY_EDITOR
+                    // Convert project-relative to absolute by combining with project root
+                    string projectRoot = Directory.GetParent(Application.dataPath)?.FullName ?? Application.dataPath;
+                    return MakeSureFolderExists(Path.Combine(projectRoot, NormalizeSlashes(projectRelativeFolder)));
+#else
+                    return Application.dataPath;
+#endif
+                case SavePathMode.PersistentDataPath:
+                    return MakeSureFolderExists(Application.persistentDataPath);
+                case SavePathMode.Absolute:
+                default:
+                    return MakeSureFolderExists(NormalizeSlashes(absoluteFolder));
+            }
+        }
+
+        public string ResolveDefaultFileAbsolute()
+        {
+            string folder = ResolveFolderAbsolute();
+            return Path.Combine(folder, string.IsNullOrEmpty(defaultFileName) ? "SceneConfig.json" : defaultFileName);
+        }
+
+        public IReadOnlyList<Type> GetComponentTypes()
+        {
+            var result = new List<Type>();
+            foreach (var script in componentScripts)
+            {
+                if (script == null) continue;
+                var type = script.GetClass();
+                if (type != null && typeof(Component).IsAssignableFrom(type))
+                {
+                    result.Add(type);
+                }
+            }
+            return result;
+        }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            // Filter non-Component entries
+            for (int i = componentScripts.Count - 1; i >= 0; i--)
+            {
+                var s = componentScripts[i];
+                if (s == null) continue;
+                var t = s.GetClass();
+                if (t == null || !typeof(Component).IsAssignableFrom(t))
+                {
+                    componentScripts.RemoveAt(i);
+                }
+            }
+        }
+#endif
+
+        private static string NormalizeSlashes(string path)
+        {
+            return string.IsNullOrEmpty(path) ? path : path.Replace('\\', '/');
+        }
+
+        private static string MakeSureFolderExists(string folder)
+        {
+            if (string.IsNullOrEmpty(folder)) return folder;
+            try
+            {
+                if (!Directory.Exists(folder))
+                {
+                    Directory.CreateDirectory(folder);
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+            return folder;
+        }
+    }
+}

--- a/Assets/Scripts/Scaffold/SceneConfig.cs
+++ b/Assets/Scripts/Scaffold/SceneConfig.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Scaffold
+{
+    [Serializable]
+    public class SceneConfig
+    {
+        public List<EntityConfig> entities = new List<EntityConfig>();
+    }
+
+    [Serializable]
+    public class EntityConfig
+    {
+        public string prefabPath;
+        public SerializableVector3 position;
+        public SerializableQuaternion rotation;
+        public SerializableVector3 scale = new SerializableVector3(1f, 1f, 1f);
+    }
+
+    [Serializable]
+    public struct SerializableVector3
+    {
+        public float x;
+        public float y;
+        public float z;
+
+        public SerializableVector3(float x, float y, float z)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        public static implicit operator Vector3(SerializableVector3 v)
+        {
+            return new Vector3(v.x, v.y, v.z);
+        }
+
+        public static implicit operator SerializableVector3(Vector3 v)
+        {
+            return new SerializableVector3(v.x, v.y, v.z);
+        }
+    }
+
+    [Serializable]
+    public struct SerializableQuaternion
+    {
+        public float x;
+        public float y;
+        public float z;
+        public float w;
+
+        public SerializableQuaternion(float x, float y, float z, float w)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+        }
+
+        public static implicit operator Quaternion(SerializableQuaternion q)
+        {
+            return new Quaternion(q.x, q.y, q.z, q.w);
+        }
+
+        public static implicit operator SerializableQuaternion(Quaternion q)
+        {
+            return new SerializableQuaternion(q.x, q.y, q.z, q.w);
+        }
+    }
+}


### PR DESCRIPTION
Adds an EditorWindow with save/load buttons for scene configurations using JSON, along with basic DTOs and an in-memory save service.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f20d5b2-9d60-4fdd-a2c8-fa26ad2b7a07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f20d5b2-9d60-4fdd-a2c8-fa26ad2b7a07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

